### PR TITLE
Extend config schemas to match parser and app behaviour

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,13 @@ jobs:
         run: npm run lint
       - name: Build
         run: npm run build
-      - name: Unit Test 
+      - name: Check documentation
+        run: |
+          if [ -n "$(git status --porcelain docs)" ]; then
+            echo "::error::Build produced changes in docs/. Run 'npm run build' and commit the result."
+            git status --porcelain docs
+            git diff docs
+            exit 1
+          fi
+      - name: Unit Test
         run: npm run test

--- a/docs/documentation/type._editables.*.format.(format-boolean).yml
+++ b/docs/documentation/type._editables.*.format.(format-boolean).yml
@@ -1,0 +1,12 @@
+gid: type._editables.*.format.(format-boolean)
+url: /configuration-file/types/_editables/*/format/(format-boolean)/
+title: ''
+description: >-
+  This key toggles whether CloudCannon will display a dropdown menu tool in your
+  WYSIWYG toolbar for structured text.
+
+
+  Setting this key to `true` will enable a dropdown menu tool in your WYSIWYG
+  toolbar for structured text with the default formats.
+examples: []
+show_in_navigation: false

--- a/docs/documentation/type._editables.*.format.(format-string).yml
+++ b/docs/documentation/type._editables.*.format.(format-string).yml
@@ -1,5 +1,5 @@
-gid: type._editables.*.format
-url: /configuration-file/types/_editables/*/format/
+gid: type._editables.*.format.(format-string)
+url: /configuration-file/types/_editables/*/format/(format-string)/
 title: ''
 description: >-
   This key toggles whether CloudCannon will display a dropdown menu tool in your
@@ -7,7 +7,7 @@ description: >-
 
 
   Setting this key enables a dropdown menu tool in your WYSIWYG toolbar for
-  structured text. Setting this to `true` uses the default formats, restrict
-  these formats with a space-separated string (e.g. `format: p h1 h2`).
+  structured text. Choose the available formats with a space-separated string
+  (e.g. `format: p h1 h2`).
 examples: []
 show_in_navigation: false

--- a/docs/documentation/type._inputs.*.options.resize_style.yml
+++ b/docs/documentation/type._inputs.*.options.resize_style.yml
@@ -4,7 +4,8 @@ title: ''
 description: >-
   This key defines how image files are resized prior to upload, using a bounding
   box defined by `width` and `height` options (these optionas are required). 
-  This key applies to existing images unless `prevent_resize_existing_files` is set.
+  This key applies to existing images unless `prevent_resize_existing_files` is
+  set.
 
   Setting this key to `cover` keeps aspect ratio and ensures the image covers
   the bounding box, `contain` keeps aspect ratio and ensures the image fits

--- a/docs/documentation/type.snippet-reference.ref.yml
+++ b/docs/documentation/type.snippet-reference.ref.yml
@@ -1,0 +1,6 @@
+gid: type.snippet-reference.ref
+url: /configuration-file/types/snippet-reference/ref/
+title: ''
+description: ''
+examples: []
+show_in_navigation: false

--- a/docs/documentation/type.snippet-reference.yml
+++ b/docs/documentation/type.snippet-reference.yml
@@ -1,0 +1,8 @@
+gid: type.snippet-reference
+url: /configuration-file/types/snippet-reference/
+title: Snippet Reference
+description: >-
+  References a reusable value defined in `_snippets_definitions` by key,
+  resolved at runtime.
+examples: []
+show_in_navigation: true

--- a/docs/documentation/type.snippet-style.between.yml
+++ b/docs/documentation/type.snippet-style.between.yml
@@ -1,0 +1,6 @@
+gid: type.snippet-style.between
+url: /configuration-file/types/snippet-style/between/
+title: ''
+description: ''
+examples: []
+show_in_navigation: false

--- a/docs/documentation/type.snippet.hidden.yml
+++ b/docs/documentation/type.snippet.hidden.yml
@@ -1,0 +1,8 @@
+gid: type.snippet.hidden
+url: /configuration-file/types/snippet/hidden/
+title: ''
+description: >-
+  Whether to hide this snippet from the editor interface. Hidden snippets are
+  still parsed, but cannot be inserted by team members.
+examples: []
+show_in_navigation: false

--- a/docs/documentation/type.snippet.params.*.options.format.yml
+++ b/docs/documentation/type.snippet.params.*.options.format.yml
@@ -1,0 +1,6 @@
+gid: type.snippet.params.*.options.format
+url: /configuration-file/types/snippet/params/*/options/format/
+title: ''
+description: ''
+examples: []
+show_in_navigation: false

--- a/docs/documentation/type.snippet.preview.view.yml
+++ b/docs/documentation/type.snippet.preview.view.yml
@@ -1,0 +1,10 @@
+gid: type.snippet.preview.view
+url: /configuration-file/types/snippet/preview/view/
+title: ''
+deprecated: true
+deprecated_description: >-
+  This key is deprecated. Set `view` at the top level of the snippet
+  configuration instead.
+description: This key defines how snippets are rendered inside the editor.
+examples: []
+show_in_navigation: false

--- a/docs/documentation/type.snippet.preview.yml
+++ b/docs/documentation/type.snippet.preview.yml
@@ -1,11 +1,12 @@
 gid: type.snippet.preview
 url: /configuration-file/types/snippet/preview/
-title: ""
+title: ''
 description: >-
   This key defines the appearance of a Card.
 
 
-  You can configure Card preview for [Snippets](/documentation/articles/what-is-a-snippet/), and the Snippet modal.
+  You can configure Card preview for
+  [Snippets](/documentation/articles/what-is-a-snippet/), and the Snippet modal.
 
 
   For more information about previews, please read our documentation on
@@ -13,7 +14,8 @@ description: >-
   previews](/documentation/articles/configure-your-card-previews/).
 examples:
   - description: >-
-      In this example, we have configured the appearance of the example Snippet's text and subtext.
+      In this example, we have configured the appearance of the example
+      Snippet's text and subtext.
     language: yaml
     code: |-
       _snippets:

--- a/docs/documentation/type.snippet.preview.yml
+++ b/docs/documentation/type.snippet.preview.yml
@@ -1,0 +1,29 @@
+gid: type.snippet.preview
+url: /configuration-file/types/snippet/preview/
+title: ""
+description: >-
+  This key defines the appearance of a Card.
+
+
+  You can configure Card preview for [Snippets](/documentation/articles/what-is-a-snippet/), and the Snippet modal.
+
+
+  For more information about previews, please read our documentation on
+  [configuring card
+  previews](/documentation/articles/configure-your-card-previews/).
+examples:
+  - description: >-
+      In this example, we have configured the appearance of the example Snippet's text and subtext.
+    language: yaml
+    code: |-
+      _snippets:
+        example:
+          snippet: "<<example [[param]]>>"
+          preview:
+            text:
+              - text: Example
+            subtext:
+              - key: param
+    annotations: []
+    source: /cloudcannon.config.yml
+show_in_navigation: false

--- a/src/editables.ts
+++ b/src/editables.ts
@@ -161,11 +161,15 @@ export const ToolbarOptionsSchema = z.object({
 			'Enables a control to insert a region of raw HTML, including YouTube, Vimeo, Tweets, and other media. Embedded content is sanitized to mitigate XSS risks, which includes removing style tags. Embeds containing script tags are not loaded in the editor.',
 	}),
 
-	format: z.string().default('p h1 h2 h3 h4 h5 h6').optional().meta({
-		id: 'type._editables.*.format',
-		description:
-			'Enables a drop down menu for structured text. Has options for "p", "h1", "h2", "h3", "h4", "h5", "h6". Set as space separated options (e.g. "p h1 h2").',
-	}),
+	format: z
+		.union([z.string(), z.boolean()])
+		.default('p h1 h2 h3 h4 h5 h6')
+		.optional()
+		.meta({
+			id: 'type._editables.*.format',
+			description:
+				'Enables a drop down menu for structured text. Has options for "p", "h1", "h2", "h3", "h4", "h5", "h6". Set as space separated options (e.g. "p h1 h2"), or `true` to enable with the default options.',
+		}),
 
 	horizontalrule: z.boolean().default(false).optional().meta({
 		id: 'type._editables.*.horizontalrule',

--- a/src/editables.ts
+++ b/src/editables.ts
@@ -162,7 +162,10 @@ export const ToolbarOptionsSchema = z.object({
 	}),
 
 	format: z
-		.union([z.string(), z.boolean()])
+		.union([
+			z.string().meta({ title: 'Format String' }),
+			z.boolean().meta({ title: 'Format Boolean' }),
+		])
 		.default('p h1 h2 h3 h4 h5 h6')
 		.optional()
 		.meta({

--- a/src/input-base.ts
+++ b/src/input-base.ts
@@ -350,7 +350,6 @@ export const SharedSelectInputOptionsSchema = z.object({
 	allow_empty: z.boolean().optional().meta({
 		id: 'type._inputs.*.options.allow_empty',
 		deprecated: true,
-		description: 'Provides an empty option alongside the options provided by values.',
 	}),
 	values: z
 		.union([

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -46,8 +46,7 @@ export const PreviewEntriesSchema = z
 			id: 'type.preview-entry.(array)',
 			title: 'Array',
 		}),
-		PreviewRawTextEntrySchema,
-		PreviewFalseEntrySchema,
+		PreviewEntrySchema,
 	])
 	.meta({ id: 'PreviewEntries' });
 

--- a/src/select-values.ts
+++ b/src/select-values.ts
@@ -2,6 +2,11 @@ import * as z from 'zod';
 
 export const SelectDataValuesSchema = z
 	.union([
+		z.string().meta({
+			title: 'Data Reference',
+			description:
+				'References another dataset by key, in the form `source.key` (e.g. `ssg_data.ssgs`).',
+		}),
 		z.array(z.string()).meta({ title: 'Text Array' }),
 		z.record(z.string(), z.string()).meta({ title: 'Text Object' }),
 		z.array(z.record(z.string(), z.unknown())).meta({ title: 'Object Array' }),

--- a/src/select-values.ts
+++ b/src/select-values.ts
@@ -2,11 +2,6 @@ import * as z from 'zod';
 
 export const SelectDataValuesSchema = z
 	.union([
-		z.string().meta({
-			title: 'Data Reference',
-			description:
-				'References another dataset by key, in the form `source.key` (e.g. `ssg_data.ssgs`).',
-		}),
 		z.array(z.string()).meta({ title: 'Text Array' }),
 		z.record(z.string(), z.string()).meta({ title: 'Text Object' }),
 		z.array(z.record(z.string(), z.unknown())).meta({ title: 'Object Array' }),

--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -92,14 +92,13 @@ export const ReferenceSchema = z
 	})
 	.meta({
 		id: 'type.snippet-reference',
-		title: 'Reference',
-		description:
-			'References a reusable value defined in `_snippets_definitions` by key, resolved at runtime.',
+		title: 'Snippet Reference',
 	});
 
 export const ParserFormatConfigSchema = z
 	.union([ParserFormatSchema, ReferenceSchema])
-	.optional();
+	.optional()
+	.meta({ id: 'type.snippet.params.*.options.format' });
 
 export const ArgumentListParserConfigSchema = z.object({
 	parser: z.literal('argument_list'),
@@ -211,11 +210,7 @@ export const SnippetConfigSchema = z
 	.object({
 		...ReducedCascadeSchema.shape,
 		preview: PreviewSchema.extend({
-			view: z.enum(['card', 'inline', 'gallery']).optional().meta({
-				deprecated: true,
-				description:
-					'Legacy location for the snippet `view` option. Prefer setting `view` at the top level of the snippet config.',
-			}),
+			view: z.enum(['card', 'inline', 'gallery']).optional().meta({ deprecated: true }),
 		}).optional(),
 		picker_preview: PickerPreviewSchema.optional(),
 	})
@@ -239,10 +234,7 @@ export const SnippetConfigSchema = z
 		strict_whitespace: z.boolean().optional().meta({
 			description: 'Whether this snippet treats whitespace as-is or not.',
 		}),
-		hidden: z.boolean().default(false).optional().meta({
-			description:
-				'Whether to hide this snippet from the editor interface. Hidden snippets are still parsed, but cannot be inserted by team members.',
-		}),
+		hidden: z.boolean().default(false).optional(),
 		definitions: z.record(z.string(), z.unknown()).optional().meta({
 			description: 'The variables required for the selected template.',
 		}),

--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -28,7 +28,8 @@ export const PairedTokenSchema = z
 
 export const SnippetStyleSchema = z
 	.object({
-		output: z.enum(['legacy', 'inline', 'block']),
+		output: z.enum(['legacy', 'inline', 'block']).optional(),
+		between: z.string().optional(),
 		inline: z
 			.object({
 				leading: z.string().optional(),
@@ -85,11 +86,26 @@ export const ParserFormatSchema = z
 		title: 'Snippet Format',
 	});
 
+export const ReferenceSchema = z
+	.object({
+		ref: z.string(),
+	})
+	.meta({
+		id: 'type.snippet-reference',
+		title: 'Reference',
+		description:
+			'References a reusable value defined in `_snippets_definitions` by key, resolved at runtime.',
+	});
+
+export const ParserFormatConfigSchema = z
+	.union([ParserFormatSchema, ReferenceSchema])
+	.optional();
+
 export const ArgumentListParserConfigSchema = z.object({
 	parser: z.literal('argument_list'),
 	options: z.object({
 		models: z.array(ParserModelSchema).optional(),
-		format: ParserFormatSchema,
+		format: ParserFormatConfigSchema,
 	}),
 });
 
@@ -97,7 +113,7 @@ export const ArgumentParserConfigSchema = z.object({
 	parser: z.literal('argument'),
 	options: z.object({
 		model: ParserModelSchema,
-		format: ParserFormatSchema,
+		format: ParserFormatConfigSchema,
 	}),
 });
 
@@ -126,7 +142,7 @@ export const KeyValueListParserConfigSchema = z.object({
 	options: z
 		.object({
 			models: z.array(ParserModelSchema),
-			format: ParserFormatSchema,
+			format: ParserFormatConfigSchema,
 			style: SnippetStyleSchema,
 		})
 		.optional(),
@@ -194,7 +210,13 @@ export const ParserConfigSchema = z.union([
 export const SnippetConfigSchema = z
 	.object({
 		...ReducedCascadeSchema.shape,
-		preview: PreviewSchema.optional(),
+		preview: PreviewSchema.extend({
+			view: z.enum(['card', 'inline', 'gallery']).optional().meta({
+				deprecated: true,
+				description:
+					'Legacy location for the snippet `view` option. Prefer setting `view` at the top level of the snippet config.',
+			}),
+		}).optional(),
 		picker_preview: PickerPreviewSchema.optional(),
 	})
 	.extend({
@@ -216,6 +238,10 @@ export const SnippetConfigSchema = z
 		}),
 		strict_whitespace: z.boolean().optional().meta({
 			description: 'Whether this snippet treats whitespace as-is or not.',
+		}),
+		hidden: z.boolean().default(false).optional().meta({
+			description:
+				'Whether to hide this snippet from the editor interface. Hidden snippets are still parsed, but cannot be inserted by team members.',
 		}),
 		definitions: z.record(z.string(), z.unknown()).optional().meta({
 			description: 'The variables required for the selected template.',


### PR DESCRIPTION
Running `npx @cloudcannon/cli validate` produced some false positives.