### PR TITLE
Fix: missing backticks on two inline code blocks

### DIFF
--- a/docs/documentation/type._inputs.*.options.max_graphemes_message.yml
+++ b/docs/documentation/type._inputs.*.options.max_graphemes_message.yml
@@ -3,6 +3,6 @@ url: /configuration-file/types/_inputs/*/options/max_graphemes_message/
 title: ''
 description: >-
   This key defines the message that explains which maximum string length an
-  Input will accept. This key requires you to define `options.max_graphemes.
+  Input will accept. This key requires you to define `options.max_graphemes`.
 examples: []
 show_in_navigation: false

--- a/docs/documentation/type._inputs.*.options.max_words_message.yml
+++ b/docs/documentation/type._inputs.*.options.max_words_message.yml
@@ -3,6 +3,6 @@ url: /configuration-file/types/_inputs/*/options/max_words_message/
 title: ''
 description: >-
   This key defines the message that explains which maximum string length an
-  Input will accept. This key requires you to define `options.max_words.
+  Input will accept. This key requires you to define `options.max_words`.
 examples: []
 show_in_navigation: false


### PR DESCRIPTION
Two inline code blocks missing the closing backtick.

Branch started off fixing just the `max_graphemes` one but I found another, so it's now two!