### PR TITLE
Fix: mismatched max_file_size values

### DIFF
--- a/docs/documentation/type._inputs.*.options.max_file_size.yml
+++ b/docs/documentation/type._inputs.*.options.max_file_size.yml
@@ -29,7 +29,7 @@ examples:
           type: image
           comment: Select the feature image for the banner.
           options:
-            max_file_size: 140
+            max_file_size: 750
     annotations: []
     source: /cloudcannon.config.yml
 show_in_navigation: false

--- a/docs/documentation/type._inputs.*.options.max_file_size_message.yml
+++ b/docs/documentation/type._inputs.*.options.max_file_size_message.yml
@@ -24,8 +24,8 @@ examples:
           type: image
           comment: Select the feature image for the banner.
           options:
-            max_file_size: 140
-            max_file_size_message: For SEO, keep this under 140kB
+            max_file_size: 750
+            max_file_size_message: For SEO, keep this under 750kB
     annotations: []
     source: /cloudcannon.config.yml
 show_in_navigation: false


### PR DESCRIPTION
The doc entry says `This Input limits you to a maximum file size of 750kB.` but then the actual example has `140` as the value.

Could easily be the entry text that is incorrect too, so happy to revise and swap them around the other way.